### PR TITLE
Update JsignJcaProvider.java

### DIFF
--- a/jsign-core/src/main/java/net/jsign/jca/JsignJcaProvider.java
+++ b/jsign-core/src/main/java/net/jsign/jca/JsignJcaProvider.java
@@ -102,7 +102,12 @@ public class JsignJcaProvider extends Provider {
         public JsignJcaKeyStore(KeyStoreType type, String keystore) {
             builder.storetype(type);
             builder.keystore(keystore);
-            builder.certfile("");
+            String certfile = System.getProperty("jsign.certfile");
+            if (certfile == null) {
+                builder.certfile("");
+            } else {
+                builder.certfile(certfile);
+            }
         }
 
         private KeyStore getKeyStore() throws KeyStoreException {


### PR DESCRIPTION
Adds ability for JsignJcaProvider to use a system property for the certificate.

Useful in cases where certificate cannot be passed via the tool that is using the JCA, e.g. apksigner.